### PR TITLE
WIP: Wagalytics Multisite Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Wagtail Analytics
+# Wagtail Analytics - NYPR Fork
+
+### Includes the following patches on top of upstream master:
+PR | Status
+-- | ------
+Multisite Analytics Support | Open
+
+(Last Updated 12/17/19 for Wagalytics v2.6.1)
 
 This module provides a simple dashboard of Google Analytics data, integrated into the Wagtail admin UI. Tested on Wagtail 1.4+.
 
@@ -27,6 +34,44 @@ If you get CryptoUnavailableError errors, you probably need to `pip install PyOp
 
 Ensure that your code snippet is included on each page you want to be tracked (likely by putting it in your base.html template.) (Admin > Property > Tracking Code)
 
+## Multisite Support 
+
+To enable multisite support you'll need to update your Wagalytics settings _and_ have `wagtail.contrib.settings` installed. Sites can use a `GA_KEY_FILEPATH` or a `GA_KEY_CONTENT` key, but it's best not to use both. 
+
+In the snippet below, you'll see `site_id`. This is the ID (Priamry Key) of your Wagtail Site. 
+```python 
+# Use either the GA_KEY_FILEPATH or the GA_KEY_CONTENT setting on your sites, 
+# but don't use both
+WAGALYTICS_SETTINGS = {
+    site_id: {
+        'GA_VIEW_ID': 'ga:xxxxxxxx',
+        'GA_KEY_FILEPATH': '/path/to/secure/directory/your-key.json',
+    },
+    site_id: { 
+        'GA_VIEW_ID': 'ga:xxxxxxxx', 
+        'GA_KEY_CONTENT': 'content_of_your_key.json',
+	}
+}
+```
+For every Wagalytics site you add in your multisite `WAGALYTICS_SETTINGS` you'll need to make sure you have the proper GA View ID and API Key. One View ID and API Key won't work for all your sites automatically. 
+
+Here's a working example of _almost live_ WAGALYTICS_SETTINGS:
+
+```python
+WAGALYTICS_SETTINGS = {
+	# My default site. 2 is the site ID. This one uses GA_KEY_FILEPATH.
+    2: {
+        'GA_VIEW_ID': 'ga:xxxxxxxx',
+        'GA_KEY_FILEPATH': '/path/to/secure/directory/your-key.json',
+    },
+    # The secondary site. 3 is the Site ID. This one uses GA_KEY_CONTENT.
+    3: {
+        'GA_KEY_CONTENT': 'content_of_your_key.json',
+        'GA_VIEW_ID': 'ga:xxxxxxxx',
+    }
+}
+```
+
 ## Wagalytics Developers
 
 Developers will need to carry out the following steps after cloning wagalytics:
@@ -45,7 +90,7 @@ You will need to run `npm run build` anytime the javascript source is updated.
 
 ### Notes
 
-This module doesn't help with recording user activity. See [the Wagtail docs](http://docs.wagtail.io/en/v1.3.1/topics/writing_templates.html?highlight=analytics#varying-output-between-preview-and-live) and [StackOverflow](http://stackoverflow.com/a/1272312/181793) for pointers on how to avoid gathering data during preview and testing.
+This module doesn't help with recording user activity. See [the Wagtail docs](http://docs.wagtail.io/en/latest/topics/writing_templates.html?highlight=analytics#varying-output-between-preview-and-live) and [StackOverflow](http://stackoverflow.com/a/1272312/181793) for pointers on how to avoid gathering data during preview and testing.
 
 ### Contributors
 

--- a/wagalytics/templates/wagalytics/dashboard.html
+++ b/wagalytics/templates/wagalytics/dashboard.html
@@ -42,7 +42,7 @@
       }
 
       .wagalytics table.listing td.title:first-child {
-        width: 100%;
+        width: 90%;
       }
 
       footer .actions {
@@ -92,6 +92,16 @@
                     </li>
                 </ul>
             </form>
+            {% if site_switcher %}
+                <div class="right" style='margin-left: 20px;'>
+                    <form method="get" id="settings-site-switch" novalidate>
+                        <label for="{{ site_switcher.site.id_for_label }}">
+                            Site:
+                        </label>
+                        {{ site_switcher.site }}
+                    </form>
+                </div>
+            {% endif %}
         </div>
     </header>
 
@@ -127,7 +137,7 @@
         </ul>
     </footer>
 
-    <div hidden id="wagalytics-data" data-token="{% url 'wagalytics_token' %}" data-view-id="{{ ga_view_id }}">
+    <div hidden id="wagalytics-data" data-token="{% url 'wagalytics_site_token' site_id %}" data-view-id="{{ ga_view_id }}">
     </div>
 {% endblock %}
 
@@ -136,4 +146,5 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
     <script src="{% static 'wagalytics/vendors.bundle.js' %}"></script>
     <script src="{% static 'wagalytics/wagalytics.bundle.js' %}"></script>
+    {{ site_switcher.media.js }}
 {% endblock %}

--- a/wagalytics/urls.py
+++ b/wagalytics/urls.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, unicode_literals
+from django.urls import path
+from django.views.decorators.cache import cache_page
+
 from .views import dashboard, token, export
 
-try:
-    from django.urls import re_path
-except ImportError:  # fallback for Django <2.0
-    from django.conf.urls import url as re_path
-
 urlpatterns = [
-    re_path(r'^dashboard/$', dashboard, name='wagalytics_dashboard'),
-    re_path(r'^token/$', token, name='wagalytics_token'),
-    re_path(r'^export/$', export, name='wagalytics_export'),
+    path('dashboard/', dashboard, name='wagalytics_dashboard'),
+    path('dashboard/<int:site_id>/', dashboard, name='wagalytics_site_dashboard'),
+    path('token/', token, name='wagalytics_token'),
+    path('token/<int:site_id>/', cache_page(3600)(token), name='wagalytics_site_token'),
+    path('export/', export, name='wagalytics_export'),
 ]

--- a/wagalytics/views.py
+++ b/wagalytics/views.py
@@ -2,18 +2,35 @@ import json
 import datetime
 from io import BytesIO
 from oauth2client.service_account import ServiceAccountCredentials
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, get_object_or_404
 from django.conf import settings
-from django.views.decorators.cache import cache_page
+from django.contrib import messages
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils import timezone
+from django.urls import reverse
 from collections import OrderedDict
 from pyexcel_ods import save_data
 
+from wagtail.contrib.settings.forms import SiteSwitchForm as SettingsSiteSwitchForm
+from wagtail.core.models import Site
+
+
+class SiteSwitchForm(SettingsSiteSwitchForm):
+    """Overwrite the get_change_url() method from SiteSwitchForm."""
+
+    @classmethod
+    def get_change_url(cls, site, model):
+        """Change the url based on the Site."""
+        return reverse('wagalytics_site_dashboard', args=[site.pk])
+
+
 def get_access_token(ga_key_filepath):
-    # from https://ga-dev-tools.appspot.com/embed-api/server-side-authorization/
-    # Defines a method to get an access token from the credentials object.
-    # The access token is automatically refreshed if it has expired.
+    """Get the access token for Google Analytics.
+
+    from https://ga-dev-tools.appspot.com/embed-api/server-side-authorization/
+    Defines a method to get an access token from the credentials object.
+    The access token is automatically refreshed if it has expired.
+    """
 
     # The scope for the OAuth2 request.
     SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
@@ -24,10 +41,14 @@ def get_access_token(ga_key_filepath):
 
     return _credentials.get_access_token().access_token
 
+
 def get_access_token_from_str(ga_key_content):
-    # from https://ga-dev-tools.appspot.com/embed-api/server-side-authorization/
-    # Defines a method to get an access token from the credentials object.
-    # The access token is automatically refreshed if it has expired.
+    """Get the access token from a string.
+
+    from https://ga-dev-tools.appspot.com/embed-api/server-side-authorization/
+    Defines a method to get an access token from the credentials object.
+    The access token is automatically refreshed if it has expired.
+    """
 
     # The scope for the OAuth2 request.
     SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
@@ -39,25 +60,104 @@ def get_access_token_from_str(ga_key_content):
 
     return _credentials.get_access_token().access_token
 
-@cache_page(3600)
-def token(request):
-    # return a cached access token to ajax clients
-    if (hasattr(settings, 'GA_KEY_CONTENT') and settings.GA_KEY_CONTENT != ''):
-        access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
+
+def token(request, site_id=None):
+    """Generate the token.
+
+    Will detect Wagalyics Multisite settings.
+    Defaults to single-site settings.
+    """
+
+    if hasattr(settings, 'WAGALYTICS_SETTINGS'):
+        if site_id is None:
+            site_id = request.site.id
+        wagalytics_settings = settings.WAGALYTICS_SETTINGS[site_id]
+        if wagalytics_settings.get('GA_KEY_CONTENT', None):
+            access_token = get_access_token_from_str(wagalytics_settings['GA_KEY_CONTENT'])
+        else:
+            access_token = get_access_token(wagalytics_settings['GA_KEY_FILEPATH'])
     else:
-        access_token = get_access_token(settings.GA_KEY_FILEPATH)
+        if (hasattr(settings, 'GA_KEY_CONTENT') and settings.GA_KEY_CONTENT != ''):
+            access_token = get_access_token_from_str(settings.GA_KEY_CONTENT)
+        else:
+            access_token = get_access_token(settings.GA_KEY_FILEPATH)
 
     return HttpResponse(access_token)
 
-def dashboard(request):
+
+def dashboard(request, site_id=None):
+    """Display the Wagalytics Dashboard.
+
+    If a site_id is provided, the dashboard will display an instance of a multi site.
+    """
+    # If there is no site_id provided in the URL but WAGALYTICS_SETTINGS have been set,
+    # Redirect the viewer to the site main site.
+    # Default redirect will be to the current site they are. ie. ^analytics/dashboard/2/$
+    if not site_id and (hasattr(settings, 'WAGALYTICS_SETTINGS') and len(settings.WAGALYTICS_SETTINGS) > 0):
+        # This site has multi-site wagalytics enabled.
+        # Redirect user to ^analytics/dashboard/{site_id}/$
+        return redirect('wagalytics_site_dashboard', site_id=request.site.id)
+
     initial_start_date = (timezone.now() - datetime.timedelta(days=30)).strftime("%Y-%m-%d")
+    ga_view_id = None
+
+    if site_id:
+        # Multisite analytics URL is being used.
+        # The URL being used looks something like this: ^/analytics/dashboard/2/$
+
+        # Look for the site object, or 404.
+        site = get_object_or_404(Site, id=site_id)
+
+        # Check for wagtail.contrib.settings app. Without it, the SiteSwitcher is not available.
+        if 'wagtail.contrib.settings' not in settings.INSTALLED_APPS:
+            display_message = "You must enable the Wagtail Site Settings app for " \
+                              "Multisite Wagalytics to work properly."
+            messages.error(request, display_message)
+
+        # Check for WAGALYTICS_SETTINGS
+        if not hasattr(settings, 'WAGALYTICS_SETTINGS'):
+            # Has no WAGALYTICS_SETTINGS at all
+            messages.error(request, "You are missing Wagalytics Multisite settings.")
+        elif not settings.WAGALYTICS_SETTINGS[site.id]:
+            # Has WAGALYTICS_SETTINGS but doesn't have settings for this specific site.
+            display_message = "You have Wagalytics Multisite settings, but not " \
+                              "for this site. Please add your settings for this site."
+            messages.error(request, display_message)
+        else:
+            # Has WAGALYTICS_SETTINGS for this specific site.
+            # Assign WAGALYTICS_SETTINGS[site_id]['GA_VIEW_ID] to ga_view_id for local use
+            ga_view_id = settings.WAGALYTICS_SETTINGS[site.id]['GA_VIEW_ID']
+    else:
+        # The regular ^analytics/dashboard/$ url is being viewed.
+        site = Site.objects.get(hostname=request.site.hostname)
+        try:
+            ga_view_id = settings.GA_VIEW_ID
+        except AttributeError:
+            display_message = "You are missing your GA_VIEW_ID setting. Your " \
+                              "analytics dashboard won't load without this setting."
+            messages.error(request, display_message)
+
+        if not hasattr(settings, 'GA_KEY_FILEPATH') and not hasattr(settings, 'GA_KEY_CONTENT'):
+            display_message = "You are missing your GA_KEY_FILEPATH or your "\
+                              "GA_KEY_CONTENT setting."
+            messages.error(request, display_message)
+
+    # Check if a SiteSwitcher is required and add it. Otherwise return None.
+    # SiteSwitcher is disabled by default.
+    site_switcher = None
+    if Site.objects.count() > 1 and hasattr(settings, 'WAGALYTICS_SETTINGS'):
+        site_switcher = SiteSwitchForm(site, Site)
 
     return render(request, 'wagalytics/dashboard.html', {
-        'ga_view_id': settings.GA_VIEW_ID,
+        'ga_view_id': ga_view_id,
         'initial_start_date': initial_start_date,
+        'site_switcher': site_switcher,
+        'site_id': site.id,
     })
 
+
 def export(request):
+    """Export the data in the current view."""
     # Get JSON string posted to `data`
     raw_data = request.POST.get('data')
 

--- a/wagalytics/wagtail_hooks.py
+++ b/wagalytics/wagtail_hooks.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 try:
@@ -37,56 +36,3 @@ def register_styleguide_menu_item():
         classnames='icon icon-fa-bar-chart',
         order=1000
     )
-
-@hooks.register('insert_editor_js')
-def editor_js():
-    return """
-        <script>
-            (function(w,d,s,g,js,fs){
-              g=w.gapi||(w.gapi={});g.analytics={q:[],ready:function(f){this.q.push(f);}};
-              js=d.createElement(s);fs=d.getElementsByTagName(s)[0];
-              js.src='https://apis.google.com/js/platform.js';
-              fs.parentNode.insertBefore(js,fs);js.onload=function(){g.load('analytics');};
-            }(window,document,'script'));
-        </script>
-        <script>
-            function fetchGAResults(slug) {
-                params = {
-                    'ids': '%s',
-                    'start-date': 'yesterday',
-                    'end-date': 'today',
-                    'metrics': 'ga:pageviews',
-                    'filters': 'ga:pagePath==' + slug
-                }
-                apiQuery = gapi.client.analytics.data.ga.get(params)
-                apiQuery.execute(handleCoreReportingResults);
-            }
-
-            function handleCoreReportingResults(results) {
-                if (!results.error) {
-                    if (results.rows && results.rows.length)
-                        showResults(results.rows[0][0]);
-                } else {
-                    alert('Something broke: ' + results.message);
-                }
-            }
-
-            function showResults(yesterday_page_views) {
-                html_results = '<li class="object"><h2><label>Analytics</label></h2><fieldset>';
-                html_results += 'This page has had <strong>' + yesterday_page_views + '</strong>';
-                html_results += ' views in the last 24 hours.</fieldset></li>';
-                $('#settings ul[class="objects"]').append(html_results);
-            }
-
-            gapi.analytics.ready(function() {
-                $.get( "%s", function(data) {
-                    gapi.analytics.auth.authorize({
-                      'serverAuth': {'access_token': data}
-                    });
-                    // Work out slug from the 'Live' link. TODO: make less fragile
-                    slug = $('a[class="status-tag primary"]').attr('href');
-                    fetchGAResults(slug);
-                });
-            })
-        </script>
-        """ % (settings.GA_VIEW_ID, reverse('wagalytics_token'))


### PR DESCRIPTION
Added in multisite Wagtail support. Each site can be configured to hold its own GA View ID, and Key Content (or Key Filepath). If there's more than one site _and_ the WAGALYTICS_SETTINGS are set, a site switcher will display (image below)
![image](https://user-images.githubusercontent.com/4743971/71038659-8cc8ff00-20df-11ea-9d95-c256c28f6546.png)

Multisite support requires `wagtail.contrib.settings` to be enabled (not a problem for your website, but still a noteworthy point). 

I've upgraded the `re_path` URLs to use Django `path`s. And also added Django Error Messages to the `dashboard` view to help guide setup.

Continued support for Single Site instances is included. 

I have a little more work to do in this PR but this is the base of adding Multisite Wagalytics. 
